### PR TITLE
Allow all minor versions of dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,8 @@ Added
 * Added README support for spanish
 * Included throttling constraints for 20 API requests per second using faraday-rate_limiter
 * Updated headers on initialization to allow for custom headers
+
+## [1.0.3](https://github.com/onfleet/ruby-onfleet/releases/tag/v1.0.3) - 2023-06-05
+Added
+* Updated package.json to reference relative path
+* Updated utils.rb to require error classes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,7 @@ Added
 Added
 * Updated package.json to reference relative path
 * Updated utils.rb to require error classes
+
+## [1.0.4](https://github.com/onfleet/ruby-onfleet/releases/tag/v1.0.4) - 2024-05-29
+Added
+* Added support for Worker's Route Delivery Manifest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,7 @@ Added
 ## [1.0.4](https://github.com/onfleet/ruby-onfleet/releases/tag/v1.0.4) - 2024-05-29
 Added
 * Added support for Worker's Route Delivery Manifest
+
+## [1.0.5](https://github.com/onfleet/ruby-onfleet/releases/tag/v1.0.5) - 2024-06-26
+Added
+* Update to RubyGems release

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'faraday'
+gem 'faraday-net_http'
 gem 'faraday-rate_limiter'
 gem 'json'
 gem 'rspec'

--- a/README.es.md
+++ b/README.es.md
@@ -89,7 +89,7 @@ Estas son las operaciones disponibles para cada endpoint:
 |[tasks](https://docs.onfleet.com/reference/tasks)|get(id)<br />list(queryParameters={})<br />get_by_short_id(shortId)|create(body={})<br />batch_create(body={})<br />batch_create_async(body={})<br />complete(id, body={})<br />clone(id)<br />auto_assign(body={})<br />match_metadata(body={})|update(id, body={})|delete(id)|
 |[teams](https://docs.onfleet.com/reference/teams)|get(id)<br />list()<br />driver_time_estimate(workerId, queryParameters={})<br />get_unassigned_tasks(id)|create(body={})<br />auto_dispatch(id, body={})|update(id, body={})<br />insert_task(teamId, body={})|delete(id)|
 |[webhooks](https://docs.onfleet.com/reference/webhooks)|list()|create(body={})|X|delete(id)|
-|[workers](https://docs.onfleet.com/reference/workers)|get(id=nil, queryParameters={})<br />get_tasks(id)<br />get_by_location(longitude, latitude, radius)<br />get_schedule(id)|create(body={})<br />set_schedule(id, body={})<br />match_metadata(body={})|update(id, body={})<br />insert_task(id, body={})|delete(id)|
+|[workers](https://docs.onfleet.com/reference/workers)|get(id=nil, queryParameters={})<br />get_tasks(id)<br />get_by_location(longitude, latitude, radius)<br />get_schedule(id)|create(body={})<br />set_schedule(id, body={})<br />match_metadata(body={})<br />get_delivery_manifest(body={}, googleApiKey, queryParameters={})|update(id, body={})<br />insert_task(id, body={})|delete(id)|
 
 ### **Peticiones GET**
 Para obtener todos los objetos de entidad dentro de un endpoint, use `list`:
@@ -176,6 +176,17 @@ workers = Onfleet::Workers.new
 workers.create(config, body)
 ```
 
+Examples of `get_delivery_manifest()`:
+```
+body = {
+  "path": "providers/manifest/generate?hubId=<workerId>&workerId=<workerId>",
+  "method": "GET"
+}
+
+workers = Onfleet::Workers.new
+workers.create(config, body, 'google_api_key', queryParameters={'startDate': '1455072025000', 'endDate': '1455072025000'})
+```
+
 Las solicitudes POST extendidas incluyen clon, batch_create, auto_assign en el endpoint de las tareas; set_schedule en el endpoint de los trabajadores; y auto_dispatch en el endpoint de los equipos. A continuación, se muestran ejemplos de estos endpoints:
 
 ```
@@ -186,12 +197,13 @@ tasks.auto_assign(config, body)
 
 workers = Onfleet::Workers.new
 workers.set_schedule(config, 'id', body)
+workers.get_delivery_manfiest(config, body, 'google_api_key', queryParameters={})
 
 teams = Onfleet::Teams.new
 teams.auto_dispatch(config, 'id', body)
 ```
 
-Para más detalles, consulte nuestra documentación en [clone](https://docs.onfleet.com/reference#clone-task), [batch_create](https://docs.onfleet.com/reference#create-tasks-in-batch), [auto_assign](https://docs.onfleet.com/reference#automatically-assign-list-of-tasks), [set_schedule](https://docs.onfleet.com/reference#set-workers-schedule), y [auto_dispatch](https://docs.onfleet.com/reference#team-auto-dispatch).
+Para más detalles, consulte nuestra documentación en [clone](https://docs.onfleet.com/reference#clone-task), [batch_create](https://docs.onfleet.com/reference#create-tasks-in-batch), [auto_assign](https://docs.onfleet.com/reference#automatically-assign-list-of-tasks), [set_schedule](https://docs.onfleet.com/reference#set-workers-schedule), [get_delivery_manifest](https://docs.onfleet.com/reference/delivery-manifest) y [auto_dispatch](https://docs.onfleet.com/reference#team-auto-dispatch).
 
 ### **Peticiones PUT**
 Para actualizar un objeto de entidad dentro de un endpoint:

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Here are the operations available for each entity:
 |[tasks](https://docs.onfleet.com/reference/tasks)|get(id)<br />list(queryParameters={})<br />get_by_short_id(shortId)|create(body={})<br />batch_create(body={})<br />batch_create_async(body={})<br />complete(id, body={})<br />clone(id)<br />auto_assign(body={})<br />match_metadata(body={})|update(id, body={})|delete(id)|
 |[teams](https://docs.onfleet.com/reference/teams)|get(id)<br />list()<br />driver_time_estimate(workerId, queryParameters={})<br />get_unassigned_tasks(id)|create(body={})<br />auto_dispatch(id, body={})|update(id, body={})<br />insert_task(teamId, body={})|delete(id)|
 |[webhooks](https://docs.onfleet.com/reference/webhooks)|list()|create(body={})|X|delete(id)|
-|[workers](https://docs.onfleet.com/reference/workers)|get(id=nil, queryParameters={})<br />get_tasks(id)<br />get_by_location(longitude, latitude, radius)<br />get_schedule(id)|create(body={})<br />set_schedule(id, body={})<br />match_metadata(body={})|update(id, body={})<br />insert_task(id, body={})|delete(id)|
+|[workers](https://docs.onfleet.com/reference/workers)|get(id=nil, queryParameters={})<br />get_tasks(id)<br />get_by_location(longitude, latitude, radius)<br />get_schedule(id)|create(body={})<br />set_schedule(id, body={})<br />match_metadata(body={})<br />get_delivery_manifest(body={}, googleApiKey, queryParameters={})|update(id, body={})<br />insert_task(id, body={})|delete(id)|
 
 ### **GET Requests**
 To get all the entity objects within an endpoint use `list`:
@@ -174,6 +174,17 @@ workers = Onfleet::Workers.new
 workers.create(config, body)
 ```
 
+Examples of `get_delivery_manifest()`:
+```
+body = {
+  "path": "providers/manifest/generate?hubId=<workerId>&workerId=<workerId>",
+  "method": "GET"
+}
+
+workers = Onfleet::Workers.new
+workers.create(config, body, 'google_api_key', queryParameters={'startDate': '1455072025000', 'endDate': '1455072025000'})
+```
+
 Extended POST requests include clone, batch_create, auto_assign on the tasks endpoint; set_schedule on the workers endpoint; and auto_dispatch on the teams endpoint. Examples of these endpoints are below:
 
 ```
@@ -184,12 +195,13 @@ tasks.auto_assign(config, body)
 
 workers = Onfleet::Workers.new
 workers.set_schedule(config, 'id', body)
+workers.get_delivery_manfiest(config, body, 'google_api_key', queryParameters={})
 
 teams = Onfleet::Teams.new
 teams.auto_dispatch(config, 'id', body)
 ```
 
-For more details, check our documentation on [clone](https://docs.onfleet.com/reference#clone-task), [batch_create](https://docs.onfleet.com/reference#create-tasks-in-batch), [auto_assign](https://docs.onfleet.com/reference#automatically-assign-list-of-tasks), [set_schedule](https://docs.onfleet.com/reference#set-workers-schedule), and [auto_dispatch](https://docs.onfleet.com/reference#team-auto-dispatch).
+For more details, check our documentation on [clone](https://docs.onfleet.com/reference#clone-task), [batch_create](https://docs.onfleet.com/reference#create-tasks-in-batch), [auto_assign](https://docs.onfleet.com/reference#automatically-assign-list-of-tasks), [set_schedule](https://docs.onfleet.com/reference#set-workers-schedule), [get_delivery_manifest](https://docs.onfleet.com/reference/delivery-manifest) and [auto_dispatch](https://docs.onfleet.com/reference#team-auto-dispatch).
 
 ### **PUT Requests**
 To update an entity object within an endpoint:

--- a/lib/resources/workers.rb
+++ b/lib/resources/workers.rb
@@ -73,7 +73,7 @@ module Onfleet
       Onfleet.request(config, method.to_sym, path, body.to_json)
     end
 
-    def get_delivery_manifest(config, body, google_api_key, query_parameters_hash)
+    def get_delivery_manifest(config, body, google_api_key = nil, query_parameters_hash = nil)
       method = 'post'
       query_parameters = nil
       

--- a/lib/resources/workers.rb
+++ b/lib/resources/workers.rb
@@ -73,6 +73,22 @@ module Onfleet
       Onfleet.request(config, method.to_sym, path, body.to_json)
     end
 
+    def get_delivery_manifest(config, body, google_api_key, query_parameters_hash)
+      method = 'post'
+      query_parameters = nil
+      
+      if google_api_key
+        config.headers['X-Api-Key'] = "Google #{google_api_key}"
+      end
+      
+      if query_parameters_hash
+        query_parameters = URI.encode_www_form(query_parameters_hash)
+      end
+      path = "integrations/marketplace?#{query_parameters}"
+
+      Onfleet.request(config, method.to_sym, path, body.to_json)
+    end
+
     # ACTION: still needs to be tested
     def insert_task(config, worker_id, body)
       method = 'put'

--- a/lib/test/test_data.json
+++ b/lib/test/test_data.json
@@ -1996,6 +1996,49 @@
                     }
                 ]
             }
+        },
+        "getManifestProvider": {
+            "request": {
+                "path": "providers/manifest/generate?hubId=<hubId>&workerId=<workerId>",
+                "method": "GET"
+            },
+            "response": {
+                "manifestDate": 1694199600000,
+                "departureTime": 1694199600000,
+                "driver": {
+                "name": "Test One",
+                "phone": "+16265555768"
+                },
+                "vehicle": {
+                "type": "CAR",
+                "description": "Honda",
+                "licensePlate": "12345687",
+                "color": "Purple",
+                "timeLastModified": 1692746334342
+                },
+                "hubAddress": "1111 South Figueroa Street, Los Angeles, California 90015",
+                "turnByTurn": [
+                    {
+                    "start_address": "1403 W Pico Blvd, Los Angeles, CA 90015, USA",
+                    "end_address": "2695 E Katella Ave, Anaheim, CA 92806, USA",
+                    "eta": 1692992466000,
+                    "driving_distance": "30.6 mi",
+                        "steps": [
+                            "Head southeast on 12th St E toward S Figueroa StPartial restricted usage road",
+                            "Turn right onto Flower St",
+                            "Turn left onto the Interstate 10 E ramp to 18th St",
+                            "Merge onto I-10 E",
+                            "Take the exit onto I-5 S toward Santa Ana",
+                            "Take exit 109A for Katella Ave",
+                            "Turn right onto E Katella AvePass by Comerica Bank (on the right in 1.3 mi)",
+                            "Turn left onto S Douglass Rd",
+                            "Turn right onto Stanley Cup Wy",
+                            "Turn right"
+                        ]
+                    }
+                ],
+                "totalDistance": null
+            }
         }
     }
 }

--- a/lib/test/test_data.json
+++ b/lib/test/test_data.json
@@ -1997,9 +1997,9 @@
                 ]
             }
         },
-        "getManifestProvider": {
+        "get_delivery_manifest": {
             "request": {
-                "path": "providers/manifest/generate?hubId=<hubId>&workerId=<workerId>",
+                "path": "providers/manifest/generate?hubId=kyfYe*wyVbqfomP2HTn5dAe1&workerId=kBUZAb7pREtRn*8wIUCpjnPu",
                 "method": "GET"
             },
             "response": {

--- a/lib/test/test_onfleet.rb
+++ b/lib/test/test_onfleet.rb
@@ -1024,7 +1024,7 @@ describe Onfleet::Workers do
       .to_return(status: 200, body: response_data.to_json)
 
     worker = Onfleet::Workers.new
-    response = worker.get_delivery_manifest(config, request_data['w'], request_data)
+    response = worker.get_delivery_manifest(config, request_data, 'google_api_key', queryParameters={'startDate': '1455072025000', 'endDate': '1455072025000'})
 
     expect(response.status).to eq 200
     expect(response.body).to include('manifestDate')

--- a/lib/test/test_onfleet.rb
+++ b/lib/test/test_onfleet.rb
@@ -15,6 +15,9 @@ require_relative '../resources/teams'
 require_relative '../resources/webhooks'
 require_relative '../resources/workers'
 
+# WebMock blocks HTTP requests in integration tests, but you can either stub the request or call WebMock.allow_net_connect! to configure the tests to run as normal.
+WebMock.allow_net_connect!
+
 # RSpec configuration setup for unit tests
 RSpec.configure do |config|
   file = File.read('./test_data.json')
@@ -22,7 +25,7 @@ RSpec.configure do |config|
   config.test_data = JSON.parse(file)
 
   config.add_setting :api_variables
-  config.api_variables = Onfleet::Configuration.new("f70dd381f0366c721677fb7e088b83bd","https://staging.onfleet.com/api/v2")
+  config.api_variables = Onfleet::Configuration.new("f70dd381f0366c721677fb7e088b83bd","https://stable1.onfleet.com/api/v2")
 end
 
 # Administrator entity tests

--- a/lib/test/test_onfleet.rb
+++ b/lib/test/test_onfleet.rb
@@ -1004,4 +1004,30 @@ describe Onfleet::Workers do
     expect(response.status).to eq 200
     expect(response.body).to include('entries')
   end
+
+  it 'can get Delivery Manifest by calling POST /integrations/marketplace' do
+    # request data
+    config = RSpec.configuration.api_variables
+    request_data = RSpec.configuration.test_data['workers']['get_delivery_manifest']['request']
+    path = "integrations/marketplace"
+    method = 'post'
+    headers = {}
+    headers['Content-Type'] = 'application/json'
+    headers['User-Agent'] = '@onfleet/ruby-onfleet-1.0'
+    headers['X-Api-Key'] = 'Google <google_api_key>'
+
+    # response data
+    response_data = RSpec.configuration.test_data['workers']['get_delivery_manifest']['response']
+
+    stub_request(method.to_sym, "#{config.base_url}/#{path}")
+      .with(basic_auth: [config.api_key, config.api_key], body: request_data, headers: headers)
+      .to_return(status: 200, body: response_data.to_json)
+
+    worker = Onfleet::Workers.new
+    response = worker.get_delivery_manifest(config, request_data['w'], request_data)
+
+    expect(response.status).to eq 200
+    expect(response.body).to include('manifestDate')
+    expect(response.body).to include('turnByTurn')
+  end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@onfleet/ruby-onfleet",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "Onfleet's Ruby API wrapper package",
     "main": "onfleet.rb",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@onfleet/ruby-onfleet",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "Onfleet's Ruby API wrapper package",
     "main": "onfleet.rb",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@onfleet/ruby-onfleet",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "description": "Onfleet's Ruby API wrapper package",
     "main": "onfleet.rb",
     "scripts": {

--- a/ruby-onfleet.gemspec
+++ b/ruby-onfleet.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'ruby-onfleet'
   s.version     = '1.0.4'
-  s.date        = '2023-06-05'
+  s.date        = '2024-06-10'
   s.summary     = 'Onfleet Ruby API wrapper package'
   s.description = 'The Onfleet Ruby library provides convenient access to the Onfleet API.'
   s.authors     = ['Dan Menza']

--- a/ruby-onfleet.gemspec
+++ b/ruby-onfleet.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'ruby-onfleet'
-  s.version     = '1.0.3'
+  s.version     = '1.0.4'
   s.date        = '2023-06-05'
   s.summary     = 'Onfleet Ruby API wrapper package'
   s.description = 'The Onfleet Ruby library provides convenient access to the Onfleet API.'

--- a/ruby-onfleet.gemspec
+++ b/ruby-onfleet.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'ruby-onfleet'
-  s.version     = '1.0.4'
+  s.version     = '1.0.5'
   s.date        = '2024-06-10'
   s.summary     = 'Onfleet Ruby API wrapper package'
   s.description = 'The Onfleet Ruby library provides convenient access to the Onfleet API.'

--- a/ruby-onfleet.gemspec
+++ b/ruby-onfleet.gemspec
@@ -10,7 +10,8 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.metadata    = { 'source_code_uri' => 'https://github.com/onfleet/ruby-onfleet' }
 
-  s.add_dependency('faraday', '~> 1.10.0')
+  s.add_dependency('faraday', '~> 2.9.0')
+  s.add_dependency('faraday-net_http', '~> 3.1.0')
   s.add_dependency('faraday-rate_limiter', '~> 0.0.4')
   s.add_dependency('json', '~> 2.6.3')
   s.add_dependency('uri', '~> 0.12.1')

--- a/ruby-onfleet.gemspec
+++ b/ruby-onfleet.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'ruby-onfleet'
-  s.version     = '1.0.2'
-  s.date        = '2023-05-19'
+  s.version     = '1.0.3'
+  s.date        = '2023-06-05'
   s.summary     = 'Onfleet Ruby API wrapper package'
   s.description = 'The Onfleet Ruby library provides convenient access to the Onfleet API.'
   s.authors     = ['Dan Menza']

--- a/ruby-onfleet.gemspec
+++ b/ruby-onfleet.gemspec
@@ -10,13 +10,15 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.metadata    = { 'source_code_uri' => 'https://github.com/onfleet/ruby-onfleet' }
 
-  s.add_dependency('faraday', '~> 2.9.0')
-  s.add_dependency('faraday-net_http', '~> 3.1.0')
-  s.add_dependency('faraday-rate_limiter', '~> 0.0.4')
-  s.add_dependency('json', '~> 2.6.3')
+  # Pin to current major versions but allow minor version updates.
+  # These libraries are long-standing with no history of breaking changes in minor versions.
+  s.add_dependency('faraday', '< 3')
+  s.add_dependency('faraday-net_http', '< 4')
+  s.add_dependency('faraday-rate_limiter', '< 1')
+  s.add_dependency('json', '< 3')
 
-  s.add_development_dependency('rspec', '~> 3.12.0')
-  s.add_development_dependency('webmock', '~> 3.18.1')
+  s.add_development_dependency('rspec', '< 4')
+  s.add_development_dependency('webmock', '< 4')
 
   s.files         = `git ls-files`.split("\n")
   s.require_paths = ['lib']

--- a/ruby-onfleet.gemspec
+++ b/ruby-onfleet.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.add_dependency('faraday-net_http', '~> 3.1.0')
   s.add_dependency('faraday-rate_limiter', '~> 0.0.4')
   s.add_dependency('json', '~> 2.6.3')
-  s.add_dependency('uri', '~> 0.12.1')
 
   s.add_development_dependency('rspec', '~> 3.12.0')
   s.add_development_dependency('webmock', '~> 3.18.1')


### PR DESCRIPTION
# Problem

Some of the dependencies in the gem are pinned to fairly old versions, though generally it doesn't appear to depend on the pessimistic version pinning of the gemspec. For example, `uri` is pinned to an older version not supported by Rails 8 but the gem only uses a single `URI.encode_www_form` method, which hasn't changed in 12 years.

# Solution

Let's just assume semver versioning will handle breaking changes for us and lock to current major versions of dependencies and be more bold about minor versions. These dependencies are widely used and unlikely to release breaking changes in a minor version update.

# Notes

Also includes the latest from `main` in the source repository, which has had a few minor updates since our fork was created (including the changes we proposed.)